### PR TITLE
Fixed a hardcoded teamredminer API port.

### DIFF
--- a/opt/ethos/lib/minerprocess.php
+++ b/opt/ethos/lib/minerprocess.php
@@ -1003,7 +1003,10 @@ function start_miner()
 			$pools .= " -o $proxypool2 -u $proxywallet$worker -p $poolpass2 ";
 		}
 		
-		$extraflags = "--api_listen=4028 --bus_reorder";
+		$extraflags = "--bus_reorder";
+		if(!preg_match("/--api_listen/",$flags)) {
+			$extraflags .= " --api_listen=4028";
+		}
 	}
 
 	/*******************************


### PR DESCRIPTION
The hardcoded option does not allow the user to set it's own setting. In case the API is not set via the ethos configurartion file, the default value (previously hardcoded) is in use