### PR TITLE
Fix hash-monitor for t-rex 0.24.7

### DIFF
--- a/opt/ethos/bin/hash-monitor
+++ b/opt/ethos/bin/hash-monitor
@@ -184,7 +184,7 @@ function get_hashrates(){
 	}
 	
 	if ($miner == "t-rex") {
-		$raw_trex_json = @json_decode(trim(`echo 'summary' | socat -t 15 stdio tcp-connect:127.0.0.1:4068`), true);
+		$raw_trex_json = @json_decode(@file_get_contents("http://127.0.0.1:4067/summary"),true);
 		$trexstats = array();
                 $raw_trex_stats = $raw_trex_json['gpus'];
                 foreach($raw_trex_stats as $id){


### PR DESCRIPTION
There is an issue with hashrate reporting because of recent changes in miner API. 
Message `possible miner stall` is showing in command prompt, but miner logs reports no issues.
Quite simple fix was applied.